### PR TITLE
Use scale area to create the gradient instead of chart area

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,11 @@ export default {
         for (const [key, options] of Object.entries(gradient)) {
           const {axis, colors} = options;
           const scale = getScale(meta, axis);
-          const value = createGradient(ctx, axis, scale);
-          addColors(value, scale, colors);
-          setValue(meta, dataset, key, value);
+          if (scale) {
+            const value = createGradient(ctx, axis, scale);
+            addColors(value, scale, colors);
+            setValue(meta, dataset, key, value);
+          }
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default {
         for (const [key, options] of Object.entries(gradient)) {
           const {axis, colors} = options;
           const scale = getScale(meta, axis);
-          const value = createGradient(ctx, axis, area);
+          const value = createGradient(ctx, axis, scale);
           addColors(value, scale, colors);
           setValue(meta, dataset, key, value);
         }


### PR DESCRIPTION
Fix  #8

This PR uses scale area, instead chart one, to create the size of the gradient