### PR TITLE
Add support to time scale with colorStop option configured with formatted dates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {Chart} from 'chart.js';
+import {isNumber} from 'chart.js/helpers';
 import ColorLib from '@kurkle/color';
 
 function createGradient(ctx, axis, area) {
@@ -7,10 +8,15 @@ function createGradient(ctx, axis, area) {
     : ctx.createLinearGradient(area.left, 0, area.right, 0);
 }
 
+function scaleValue(scale, value) {
+  const normValue = isNumber(value) ? parseFloat(value) : scale.parse(value);
+  return scale.getPixelForValue(normValue);
+}
+
 function addColors(gradient, scale, colors) {
   const reverse = scale.options.reverse;
   for (const value of Object.keys(colors)) {
-    const pixel = scale.getPixelForValue(value);
+    const pixel = scaleValue(scale, value);
     const stop = scale.getDecimalForPixel(pixel);
     if (isFinite(pixel) && isFinite(stop)) {
       gradient.addColorStop(


### PR DESCRIPTION
Fix #15.

This PR is enable the feature to use in `color` node color stop as formatted date, leveraging on scale parsing.

Example:

```javascript
gradient: {
  backgroundColor: {
    axis: 'x',
      colors: {
        "05/30/2021": 'green',
        "06/02/2021": 'blue',
        "06/04/2021": 'red'
      }
    }
  }
}
```

Time scale options:
```javascript
scales: {
  x: {
    type: 'time', 
    time: {
      unit: 'day',
      parser: 'MM/dd/yyyy',
    }
  }
}
```
![timeGradient](https://user-images.githubusercontent.com/11741250/159897768-f257ed85-94c9-4104-9a8c-70fc150fe7f7.png)

