### PR TITLE
Fix missing compatibility with CHART.JS version 2.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,12 @@ function createGradient(ctx, axis, scale) {
   return ctx.createLinearGradient(scale.left, 0, scale.right, 0);
 }
 
+const parse = Chart.version
+  ? (scale, value) => scale.parse(value)
+  : (scale, value) => value;
+
 function scaleValue(scale, value) {
-  let normValue;
-  if (isNumber(value)) {
-    normValue = parseFloat(value);
-  } else {
-    normValue = (Chart.version) ? scale.parse(value) : value;
-  }
+  const normValue = isNumber(value) ? parseFloat(value) : parse(scale, value);
   return scale.getPixelForValue(normValue);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function createGradient(ctx, axis, scale) {
 }
 
 function scaleValue(scale, value) {
-  const normValue = isNumber(value) ? parseFloat(value) : scale.parse(value);
+  const normValue = isNumber(value) ? parseFloat(value) : Chart.version ? scale.parse(value) : value;
   return scale.getPixelForValue(normValue);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,12 @@ function createGradient(ctx, axis, scale) {
 }
 
 function scaleValue(scale, value) {
-  const normValue = isNumber(value) ? parseFloat(value) : Chart.version ? scale.parse(value) : value;
+  let normValue;
+  if (isNumber(value)) {
+    normValue = parseFloat(value);
+  } else {
+    normValue = (Chart.version) ? scale.parse(value) : value;
+  }
   return scale.getPixelForValue(normValue);
 }
 


### PR DESCRIPTION
The PR # 16 introduced a breaking change, removing the support of version CHART.JS 2.x.
This PR is fixing it.
