### PR TITLE
Group dependabot updates and add standard README badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # chartjs-plugin-gradient
 
+[![npm](https://img.shields.io/npm/v/chartjs-plugin-gradient.svg)](https://www.npmjs.com/package/chartjs-plugin-gradient)
+[![release](https://img.shields.io/github/release/kurkle/chartjs-plugin-gradient.svg?style=flat-square)](https://github.com/kurkle/chartjs-plugin-gradient/releases/latest)
+![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-plugin-gradient.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-gradient&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-gradient)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-gradient&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-gradient)
+![GitHub](https://img.shields.io/github/license/kurkle/chartjs-plugin-gradient.svg)
 
 *Easy gradients for [Chart.js](https://www.chartjs.org)*
 


### PR DESCRIPTION
## Summary
- Group dependabot updates: add `dev-dependencies`/`actions` groups for the npm and github-actions ecosystems in `.github/dependabot.yml`, matching the config already used in five other kurkle repos, so routine bumps land as one PR instead of many.
- Add the standard badge row to `README.md`: npm version, GitHub release, bundlephobia min size, Sonar quality gate (already present), Sonar coverage, and GitHub license — matching the format used across the other kurkle chart.js repos. No documentation badge, since this repo has no docs site.

## Test plan
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)