### PR TITLE
Drop yargs from karma.conf.cjs to fix dependabot group PR #283

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -1,12 +1,10 @@
 const istanbul = require('rollup-plugin-istanbul')
 const json = require('@rollup/plugin-json')
 const resolve = require('@rollup/plugin-node-resolve').default
-const yargs = require('yargs')
 const env = process.env.NODE_ENV
 
 module.exports = async (karma) => {
   const builds = (await import('./rollup.config.js')).default
-  const args = yargs.option('verbose', { default: false }).argv
 
   // Use the same rollup config as our dist files: when debugging (npm run dev),
   // we will prefer the unminified build which is easier to browse and works
@@ -29,7 +27,7 @@ module.exports = async (karma) => {
     browserDisconnectTimeout: 120000,
     browserDisconnectTolerance: 3,
     browserNoActivityTimeout: 120000,
-    browsers: (args.browsers || 'chrome,firefox').split(','),
+    browsers: ['chrome', 'firefox'],
 
     // These settings deal with browser disconnects. We had seen test flakiness from Firefox
     // [Firefox 56.0.0 (Linux 0.0.0)]: Disconnected (1 times), because no message in 10000 ms.


### PR DESCRIPTION
## Summary
Dependabot's grouped dev-dependency PR (#283) fails with `TypeError: yargs.option is not a function` at `karma.conf.cjs:9`. Root cause: `yargs` was never a direct devDependency of this repo — it was only pulled in transitively by `karma` and `concurrently`, so its resolved version depended entirely on whichever version those two happened to hoist. `concurrently` 9→10 (in #283's group) requires `yargs@18`, whose CJS entry point now exports a factory function instead of a ready-made instance, so `yargs.option('verbose', ...)` throws as soon as karma loads the config.

The `--verbose` option this set up was dead code (never read anywhere), and `karma-cli` already merges a `--browsers` CLI flag into the config object before this function runs — that's how `karma.autoWatch` below already reflects `--auto-watch`/`--no-single-run`. So no yargs was actually needed. This hardcodes the browsers list instead, matching `chartjs-chart-sankey` and `chartjs-chart-treemap`, neither of which use yargs at all.

## Test plan
- [x] Reproduced the exact `yargs.option is not a function` error locally by installing #283's bumped versions (concurrently 10.0.5 → yargs 18.0.0) against the old `karma.conf.cjs`
- [x] `npm run lint` passes
- [x] `npm run build` passes, all 4 dist files generated
- [x] `npm test` (76/76, Chrome + Firefox) passes with the **currently pinned** devDependencies (yargs 17.7.2, transitively)
- [x] `npm test` (76/76) also passes with **#283's bumped versions installed** (yargs 18.0.0, transitively)
- [x] Verified `karma start ... --browsers firefox` still restricts to a single browser via karma-cli's own CLI handling (no regression from dropping yargs)

Once this merges, #283 should pass on its next scheduled/rebased run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)