### PR TITLE
Bump compressed-size-action to v3

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -36,7 +36,8 @@ jobs:
         run: npm run build
 
       - name: Compressed size
-        uses: preactjs/compressed-size-action@v2
+        uses: preactjs/compressed-size-action@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
+          build-script: "npm run build"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -22,6 +22,9 @@ jobs:
   compressed-size:
     runs-on: ubuntu-latest
     needs: [shared-ci]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary
Dependabot's actions-group PR (#282) fails with `Input required and not supplied: build-script`. `preactjs/compressed-size-action` v3 made `build-script` a required input with no default (v2 defaulted to `npm run build`), so bumping to v3 without setting it breaks.

1. Bump `preactjs/compressed-size-action` from v2 to v3 and pass `build-script: "npm run build"`. Note: `build-script` is a literal shell command the action execs itself (like `install-script`/`clean-script`), not an npm script name — an initial attempt with just `build-script: "build"` failed with `Unable to locate executable file: build`.
2. Per discussion, the job's own `Install dependencies`/`Build` steps are left in place (not removed), even though the action re-installs and rebuilds both branches internally to compare them — that's a separate optimization to consider later across repos, not part of this fix.
3. While verifying, found the job was also silently failing to post its actual PR comment (`Error creating comment: Resource not accessible by integration`) — the workflow's top-level `permissions: contents: read` doesn't grant `pull-requests: write`, and a job only inherits workflow-level permissions if it doesn't declare its own. Added a job-level `permissions` block (`contents: read` + `pull-requests: write`) scoped to just the `compressed-size` job; the other jobs don't need write access and are untouched. This isn't a regression from this PR — chartjs-chart-sankey's already-merged PR #423 shows the identical silent failure with the same permissions setup.

## Test plan
- [x] `compressed-size` check passes on this PR
- [x] The action's own logs/report show correct sizes (`Size Change: 0 B`, all 4 dist files with correct sizes) — this PR only touches CI config, so no size change is expected
- [x] Confirmed the bot comment actually appears on this PR now (not just in the Action logs) with the correct size table

🤖 Generated with [Claude Code](https://claude.com/claude-code)