### PR TITLE
Install CI dependencies with --ignore-scripts

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build
@@ -45,3 +45,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
           build-script: "npm run build"
+          install-script: "npm ci --ignore-scripts"


### PR DESCRIPTION
## Summary
Security hardening: dependency lifecycle scripts (preinstall/install/postinstall) are a common malware-distribution vector on npm. Add `--ignore-scripts` to the repo's own install steps:

1. `main-ci.yml` release job: `npm clean-install` → `npm clean-install --ignore-scripts`
2. `pr-ci.yml` compressed-size job's own install: `npm clean-install` → `npm clean-install --ignore-scripts`
3. `preactjs/compressed-size-action`'s internal install (it installs and builds both the PR branch and the base branch itself to diff them): added `install-script: "npm ci --ignore-scripts"`

The shared workflow's own install command is configured separately via `@kurkle/configs` and is out of scope for this PR.

Confirmed safe before making this change: gradient's dependency tree has no packages with install scripts other than the macOS-only, optional `fsevents` (never installed on the Linux CI runners this repo uses) — checked directly against `package-lock.json`'s `hasInstallScript` flags.

## Test plan
- [x] `npm run lint`, `npm run build`, `npm test` (76/76) all pass locally
- [x] Verified `npm ci --ignore-scripts` installs cleanly and the subsequent build/test still work
- [x] PR's own CI (`shared-ci/CI`, `shared-ci/Sonar`, `SonarCloud`, `SonarCloud Code Analysis`, `compressed-size`) all pass
- [x] Confirmed the `compressed-size` bot comment still posts correctly (same size report as before this change: `Size Change: 0 B`, all 4 dist files) — this was previously broken and fixed in #285/#286, so specifically checked it wasn't silently broken again

🤖 Generated with [Claude Code](https://claude.com/claude-code)