### PR TITLE
docs: wire Cloudflare Pages deploy into main-ci.yml

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -51,3 +51,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx --no-install semantic-release
+
+      - name: Resolve released version
+        id: release-version
+        run: |
+          VERSION=$(git describe --tags --exact-match HEAD 2>/dev/null | sed 's/^v//')
+          if [ -z "$VERSION" ]; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No release tag on HEAD, skipping Cloudflare Pages version update"
+            exit 0
+          fi
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved released version: $VERSION"
+
+      - name: Update Cloudflare Pages production docs version
+        if: steps.release-version.outputs.released == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
+        run: |
+          curl --fail --silent --show-error \
+            --request PATCH \
+            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --header 'Content-Type: application/json' \
+            --data @- <<EOF
+          {
+            "deployment_configs": {
+              "production": {
+                "env_vars": {
+                  "DOCS_VERSION": {
+                    "type": "plain_text",
+                    "value": "${DOCS_VERSION}"
+                  }
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Trigger Cloudflare Pages production deploy
+        if: steps.release-version.outputs.released == 'true'
+        env:
+          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
+        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary

Adds the post-release Cloudflare Pages deploy steps to `.github/workflows/main-ci.yml`, copied verbatim (via `gh api`, not from memory) from `kurkle/chartjs-chart-sankey`'s `main-ci.yml`, the canonical reference. `chartjs-chart-matrix` carries an identical block (just with a few inline `#` comments on the `permissions:` keys that gradient's existing style doesn't use elsewhere either).

Three new steps at the end of the `release` job, after the existing `Release` (semantic-release) step:

1. **`Resolve released version`** (`id: release-version`) — gradient's `main-ci.yml` did not have this step before this PR (checked against `origin/main`); it's required, since the two Cloudflare steps gate on `steps.release-version.outputs.released == 'true'` and that output doesn't exist without it. It resolves whether `HEAD` carries a tag semantic-release just created, and sets `released`/`version` outputs — `released=false` (with no error) when semantic-release didn't cut a release (e.g. a chore/docs-only push).
2. **`Update Cloudflare Pages production docs version`** — PATCHes the Cloudflare API to set the `production` deployment's `DOCS_VERSION` env var to the just-released version.
3. **`Trigger Cloudflare Pages production deploy`** — POSTs the deploy hook.

Both gated on `if: steps.release-version.outputs.released == 'true'`, so they're no-ops on any push that doesn't produce a new release.

## Diff against the canonical reference

The entire `release:` job block (all steps, including the three new ones) is **byte-for-byte identical** to `chartjs-chart-sankey`'s `main-ci.yml` — this workflow file has no repo-specific strings at all (no repo name, no URLs), so there was nothing to adapt. Confirmed with:

```
$ diff <(sed -n '/^  release:/,$p' sankey-main-ci.yml) <(sed -n '/^  release:/,$p' gradient-main-ci.yml)
(no output)
```

The only difference in the whole file is in the pre-existing `shared-ci` job, unrelated to this change and already on `main` before this PR: gradient's `run-typecheck: false` and `coverage-paths:` lines, which sankey's `shared-ci` job doesn't carry. Not touched here.

## Test plan

- [x] `actionlint .github/workflows/main-ci.yml` — exit 0, no findings.
- [x] Parsed with `yaml.safe_load` in Python — valid YAML, and confirmed the `release` job's step list and each new step's `if:` condition programmatically (both Cloudflare steps correctly gated on `steps.release-version.outputs.released == 'true'`).
- [x] Confirmed via `gh api` that all four secrets this workflow references already exist on the repo: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_PAGES_PROJECT`, `CLOUDFLARE_PAGES_DEPLOY_HOOK` (per the coordinator, who verified this directly).
- [x] The repo's own pre-commit hook (lint + test + build) ran and passed before the commit was accepted.

**What this cannot verify before merge:** whether the Cloudflare API calls themselves actually succeed — that only happens on the next real `push` to `main` that causes semantic-release to cut a tag, which is outside a PR's own CI run (this workflow triggers on `push` to `main`, not on `pull_request`). This PR is a syntactic/structural change verified by the above; the first real production deploy is unverified until that next release happens. Flagging this explicitly rather than presenting it as tested.

## Out of scope, not touched

- `README.md` — a separate PR immediately follows this one and also fixes the `plugins: { gradient }` registration bug found while building the docs site; not touched here.
- Everything from the docs-site PR (#288) other than this workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)