### PR TITLE
fix: port README to a quickstart, fix single-chart registration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,10 @@
 ![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-plugin-gradient.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-gradient&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-gradient)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-plugin-gradient&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-plugin-gradient)
+[![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-plugin-gradient.pages.dev)
 ![GitHub](https://img.shields.io/github/license/kurkle/chartjs-plugin-gradient.svg)
 
-*Easy gradients for [Chart.js](https://www.chartjs.org)*
-
-This plugin requires Chart.js 3.0.0 or later. It should also work with v2, but there are no regressing tests to guarantee this.
-
-**NOTE** the plugin does not automatically register.
+[Chart.js](https://www.chartjs.org/) **v3+, v4+** plugin that renders a dataset's background and/or border color as a gradient following any axis (`x`, `y`, or `r`), instead of a single flat color — for anyone already charting with Chart.js who wants a value-driven color transition instead of a solid fill or stroke. It should also work with Chart.js v2, but there are no regression tests to guarantee this.
 
 ## Example
 
@@ -19,86 +16,81 @@ This plugin requires Chart.js 3.0.0 or later. It should also work with v2, but t
 
 ## Installation
 
-NPM:
-
 ```bash
-npm i --save-dev chartjs-plugin-gradient
+npm install chart.js chartjs-plugin-gradient
 ```
 
-CDN:
+Or via CDN:
 
 ```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-gradient"></script>
 ```
 
-## Usage
-
-### loading
-
-ESM
+## Quickstart
 
 ```js
+import { Chart, registerables } from 'chart.js';
 import gradient from 'chartjs-plugin-gradient';
-```
 
-CDN
+Chart.register(...registerables, gradient);
 
-```js
-const gradient = window['chartjs-plugin-gradient'];
-```
-
-### Registering
-
-All charts
-
-```js
-Chart.register(gradient);
-```
-
-Signle chart
-
-```js
-const chart = new Chart(ctx, {
-  // ...
-  plugins: {
-    gradient
-  }
-});
-```
-
-### Configuration
-
-The gradient colors are configured in the `gradient` key of dataset
-
-```js
-const chart = new Chart(ctx, {
+new Chart(document.getElementById('chart'), {
+  type: 'line',
   data: {
-    datasets: [{
-      // data
-      gradient: {
-        backgroundColor: {
-          axis: 'y',
-          colors: {
-            0: 'red',
-            50: 'yellow',
-            100: 'green'
-          }
+    labels: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    datasets: [
+      {
+        label: 'Gradient background',
+        data: [10, 20, 15, 40, 30, 25, 60, 45, 70, 50],
+        fill: true,
+        gradient: {
+          backgroundColor: {
+            axis: 'y',
+            colors: {
+              0: 'green',
+              50: 'blue',
+              100: 'red',
+            },
+          },
         },
-        borderColor: {
-          axis: 'x',
-          colors: {
-            0: 'black',
-            1: 'white',
-            2: 'black',
-            3: 'white'
-          }
-        }
-      }
-    }]
-  }
+      },
+    ],
+  },
 });
+```
+
+`Chart.register(gradient)` enables the plugin for every chart. To register it for a single chart instead, pass it in `plugins`:
+
+```js
+new Chart(ctx, {
+  // ...
+  plugins: [gradient],
+});
+```
+
+See more integration options (script tag, other module loaders) in the [documentation](https://chartjs-plugin-gradient.pages.dev/integration/).
+
+## Documentation
+
+You can find documentation for chartjs-plugin-gradient at [https://chartjs-plugin-gradient.pages.dev/](https://chartjs-plugin-gradient.pages.dev/). The full configuration reference lives there, not in this README — this file stays a quickstart.
+
+## Development
+
+You first need to install node dependencies (requires [Node.js](https://nodejs.org/)):
+
+```bash
+> npm install
+```
+
+The following commands will then be available from the repository root:
+
+```bash
+> npm run build        // build dist files
+> npm test              // run all tests
+> npm run lint          // perform code linting
 ```
 
 ## License
 
-`chartjs-plugin-gradient.js` is available under the [MIT license](https://github.com/kurkle/chartjs-plugin-gradient/blob/main/LICENSE).
+chartjs-plugin-gradient is available under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Why `fix:`, not `docs:`

Every other README task in this fleet effort used `docs:` because a release would be wasted noise. This one is the opposite: gradient's release history is v0.6.4 (yesterday), v0.6.3 and v0.6.2 (same day) — and before that, the previous release is from **2022**. The repo was dormant for four years.

npm serves README.md from the published tarball, not from GitHub. A README fix landed as `docs:` sits un-published until the next release, and on this repo's actual history that can mean years — leaving the broken instruction (see below) visible exactly where most readers see it. This is a real, user-facing bug in published documentation, so `fix:` is both semantically correct and the only way the correction actually reaches npm in a reasonable time.

## The bug

README lines 60-66 told readers:

```
plugins: {
  gradient
}
```

Traced through Chart.js 4's actual source (the `allPlugins` function in chart.js's core bundle): it does `const local = config.plugins || []`, then loops `for (let i = 0; i < local.length; i++)`. A plain object has no `.length`, so the loop never runs and the plugin is never registered — silently, no error. Fixed to the correct array form, `plugins: [gradient]`. Verified: `plugins: {` no longer appears anywhere in the file, `plugins: [gradient]` does (line 68).

## What changed

Shrunk README.md to the same shape as chartjs-chart-sankey, chartjs-chart-matrix, and chartjs-chart-treemap (all on `main`, used as templates): badges, one intro paragraph, Example, Installation, Quickstart, Documentation, Development, License. The full Usage section (loading/registering/configuration) that used to live here now lives on the docs site the previous PR built — this file is a pointer, not a duplicate.

Added the missing `documentation` badge (linking to the now-live `https://chartjs-plugin-gradient.pages.dev`) to match all three sibling repos.

## Verifying nothing was silently dropped

I did not trust my own memory of the site I built — I checked the actual deployed pages (the docs PR merged to `main` already, and Cloudflare Pages' native GitHub integration has already built and deployed it independently of the not-yet-merged Cloudflare-wiring PR, so the pages.dev site is live right now). For every piece of content removed from the old README, here's where it lives now, confirmed by fetching the live pages and grepping the exact text:

| Old README content | Found on site? |
| --- | --- |
| "requires Chart.js 3.0.0 or later... also work with v2... no regression tests" | Yes - Getting Started page, verbatim |
| "NOTE the plugin does not automatically register" | Yes - Getting Started: "does not register itself automatically" |
| ESM loading (import gradient from the package) | Yes - Integration page |
| CDN loading (window global) | Yes - Integration page, verbatim |
| CDN script tags (jsdelivr) | Yes - Integration page (plus UNPKG and a direct-file fallback, more than the old README had) |
| Chart.register(gradient) (all charts) | Yes - Usage page |
| Single-chart registration | Yes - Usage page, already using the fixed array form (I fixed this when I wrote that page in the docs PR) |
| Full gradient key configuration example (axis/colors, both backgroundColor and borderColor) | Yes - Usage page, exact block present, plus a table explaining axis/colors |

Nothing was found missing. (Unlike the sankey precedent the coordinator mentioned, where this check caught two options that would have vanished — here everything checked out.)

The static Example image (sample.png) is kept, not removed — it's part of the standard sibling template and isn't something the docs site replaces.

## Quickstart - actually run, not memory-written

This was the point of the exercise, so I ran it for real rather than writing it from memory (writing it from memory is exactly how the original bug got into the README in the first place).

Built the ESM dist file, then ran the literal Quickstart code (global registration, the exact dataset/gradient config in the README) in Node against a headless canvas library (installed with `--no-save`, removed afterward - `git diff` on package.json/package-lock.json is empty) with a minimal `document.getElementById` shim so the browser-style code ran completely unmodified.

Result: no throw, and the rendered PNG shows a clean vertical gradient - green at the bottom, blue in the middle, red at the top, matching the configured 0/50/100 -> green/blue/red stops exactly. Numeric confirmation, sampling one vertical line of pixels top to bottom, showed a monotonic red-to-blue-to-green transition (red-dominant near the top, blue-dominant in the middle, green-dominant near the bottom) — confirming the gradient actually renders, not just that the code doesn't throw.

## Badges - every one fetched

| Badge | Checked | Result |
| --- | --- | --- |
| npm version | package registry lookup | 0.6.4 - real, published |
| release | fetched the GitHub releases/latest redirect | 200 |
| bundle size (bundlephobia) | fetched the badge | 200 (kept per existing fleet decision not to switch to bundlejs) |
| Sonar quality gate | fetched badge + linked summary page | 200 / 200 |
| Sonar coverage | fetched badge | 200 |
| documentation (new) | fetched badge + the pages.dev site | 200 / 200, live Starlight site |
| GitHub license | fetched badge | 200 |
| MIT license link (License section) | fetched | 200 |

npmjs.com's own package page blocks plain fetches with a 403 (bot protection), which is not a broken link - confirmed the package is real via a registry version lookup instead.

## Test plan

- [x] `plugins: {` no longer appears anywhere in README.md.
- [x] `plugins: [gradient]` appears in README.md (line 68).
- [x] Quickstart actually executed in Node (see above) - gradient confirmed by rendered image and per-pixel color sampling.
- [x] Every removed section cross-checked against the live, deployed docs site (table above).
- [x] Every badge/link fetched (table above).
- [x] `npm test` - 38 specs x 2 browsers = 76 SUCCESS.
- [x] `npm run lint` - clean.
- [x] `git diff` on package.json/package-lock.json - empty (temporary canvas-rendering dependency installed and removed without saving, environment restored via `npm ci`).
- [x] Repo's own pre-commit hook (lint + test + docs build) ran and passed before the commit was accepted.

## Scope

Only README.md. Did not touch the docs site, the CI workflow, or the samples/*.html files.
