### PR TITLE
docs: link autocolors ecosystem entry to its new docs site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -73,7 +73,7 @@ export default defineConfig({
             },
             {
               label: 'chartjs-plugin-autocolors',
-              link: 'https://github.com/kurkle/chartjs-plugin-autocolors',
+              link: 'https://chartjs-plugin-autocolors.pages.dev/',
             },
           ],
           label: 'Ecosystem',


### PR DESCRIPTION
## Summary

The Ecosystem sidebar block in `astro.config.mjs` still linked `chartjs-plugin-autocolors` to its GitHub repo, left over from before that repo had its own docs site. autocolors got its site today; this updates the one link.

| Before | After |
| --- | --- |
| `https://github.com/kurkle/chartjs-plugin-autocolors` | `https://chartjs-plugin-autocolors.pages.dev/` |

matrix, sankey, and treemap already point at the live sites for their siblings. `Awesome Chart.js` is left pointing at GitHub, as instructed - it isn't one of the fleet's own docs sites.

## Test plan

- [x] Fetched the new URL directly: `curl -s -o /dev/null -w "%{http_code}" -L https://chartjs-plugin-autocolors.pages.dev/` -> `200`.
- [x] `npm run docs` builds cleanly - 7 pages, same count as before.
- [x] Confirmed in the built output, not from memory: `dist/docs/index.html` contains `<a href="https://chartjs-plugin-autocolors.pages.dev/" ...>chartjs-plugin-autocolors</a>`, and the old `https://github.com/kurkle/chartjs-plugin-autocolors` string no longer appears anywhere in that file.
- [x] `npm test` - 38 specs x 2 browsers = 76 SUCCESS.
- [x] Repo's own pre-commit hook (lint + test + build + docs) ran and passed before the commit was accepted.

## A note on how this was verified

My usual local worktree hit the same `Tsconfig not found astro/tsconfigs/strict` build failure flagged in the previous PR's report - reproduced again here on a fresh `npm ci` in that worktree. Per the standing guidance on that known issue, I did not chase it further; instead I made this change (and ran every check above, including the actual commit) in a separate, clean clone of `origin/main`, where the docs build has consistently worked. The commit above was made and pushed from that clean clone, not the flaky worktree - the pre-commit hook's `npm run docs` step passing is genuine there, not bypassed.

## Scope

Only the one `link` value in `astro.config.mjs`'s Ecosystem block. Other stale-looking links (if any) are reported, not fixed, per the task's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
