### PR TITLE
ci: move Cloudflare Pages deploy into shared docs-deploy workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -29,6 +29,9 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    outputs:
+      released: ${{ steps.release-version.outputs.released }}
+      version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -65,36 +68,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved released version: $VERSION"
 
-      - name: Update Cloudflare Pages production docs version
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
-        run: |
-          curl --fail --silent --show-error \
-            --request PATCH \
-            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
-            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            --header 'Content-Type: application/json' \
-            --data @- <<EOF
-          {
-            "deployment_configs": {
-              "production": {
-                "env_vars": {
-                  "DOCS_VERSION": {
-                    "type": "plain_text",
-                    "value": "${DOCS_VERSION}"
-                  }
-                }
-              }
-            }
-          }
-          EOF
-
-      - name: Trigger Cloudflare Pages production deploy
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
-        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"
+  docs-deploy:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: kurkle/configs/.github/workflows/docs-deploy.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+      CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary

Moves the two Cloudflare Pages deploy steps out of gradient's own `main-ci.yml` and into the new shared `kurkle/configs/.github/workflows/docs-deploy.yml@v1` reusable workflow, per `configs`' README (`## Docs deploy workflow` section, read from source via `gh api repos/kurkle/configs/contents/README.md`, not from memory).

Three changes to `.github/workflows/main-ci.yml`, exactly as specified:

1. Added a job-level `outputs:` block to `release` (next to `permissions:`, before `steps:`) exposing `released` and `version` from the `release-version` step, since `needs.<job>.outputs.*` in a calling job can only see job-level outputs, not a step's own outputs.
2. Removed the `Update Cloudflare Pages production docs version` and `Trigger Cloudflare Pages production deploy` steps. **`Resolve released version` (`id: release-version`) stays** in `release` - it reads the git tag and belongs with the release itself, not the deploy, per the same README section.
3. Added a new `docs-deploy` job that calls the shared workflow, gated on `needs.release.outputs.released == 'true'`.

## Why only the Cloudflare part moves, not `release` itself

`release` job's workflow **file name** is load-bearing for npm's trusted publishing - it binds the publisher identity to `main-ci.yml`, the exact file that runs `npx semantic-release`. Moving that call into a called workflow would change the identity and break npm publishing fleet-wide. This PR only relocates the two Cloudflare `curl` steps; nothing that touches npm changes.

## Verification

- `actionlint .github/workflows/main-ci.yml` - clean, exit 0.
- Parsed with `yaml.safe_load` and inspected programmatically: `release` job's `outputs` map resolves to the two expected step-output references; `docs-deploy` job's `needs`/`if`/`uses`/`with`/`secrets` match the README's example exactly; `release`'s own `steps` list still contains both `Release` (`npx --no-install semantic-release`) and `Resolve released version` (`id: release-version`) in the same job/file.
- Confirmed the `v1` git tag on `kurkle/configs` currently points at the same commit as its `main` branch (`git ls-remote`/`gh api` comparison), and that `.github/workflows/docs-deploy.yml` exists at that ref - so `@v1` resolves to a real, current file, not a stale tag.
- Line count: `.github/workflows/main-ci.yml` went from 100 lines to 81 lines (`git diff --stat`: 14 insertions, 33 deletions).
- `npm test` - 38 specs x 2 browsers = 76 SUCCESS.
- `npm run docs` builds cleanly (unaffected by this change, but confirms the rest of the toolchain is undisturbed).
- Repo's own pre-commit hook (lint + test + build + docs) ran and passed before the commit was accepted. As with the last two PRs, this was done from a separate clean clone of `origin/main`, not the flaky worktree that still reproduces the previously-reported `Tsconfig not found astro/tsconfigs/strict` error (traced to that worktree's `.git` being a worktree-pointer file rather than a real directory, not a code issue) - the clean clone's `npm run docs` and pre-commit hook both passed genuinely there.

## What cannot be verified before the next real release

This workflow only runs its `release` and `docs-deploy` jobs on a push to `main`, and `docs-deploy` only fires when `semantic-release` actually cuts a new tag. Everything above is static/structural verification (YAML shape, `actionlint`, confirming the called workflow exists at `@v1`). Whether the `docs-deploy` job's Cloudflare API calls actually succeed, and whether the site's version stamp updates correctly end-to-end, can only be confirmed on gradient's next real release - not from this PR or any dry run.

Related to that: the live site (`chartjs-plugin-gradient.pages.dev`) still shows version `0.0.1` right now, because its most recent deploy went out via Cloudflare's native GitHub integration, before this pipeline existed. That's expected to self-correct on the next release once this is merged - not something this PR needs to fix directly.

## Scope

Only `.github/workflows/main-ci.yml`. No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
